### PR TITLE
adjusted json example in github pages

### DIFF
--- a/customizing.md
+++ b/customizing.md
@@ -42,9 +42,9 @@ A sample `config.json` might thus look like this:
 
 ```javascript
 {
-    useSideNav: true,
-    lineBreaks: "gfm",
-    additionalFooterText: "All content and images &copy; by John Doe"
+    "useSideNav": true,
+    "lineBreaks": "gfm",
+    "additionalFooterText": "All content and images &copy; by John Doe"
 }
 ```
 


### PR DESCRIPTION
When I had copied the config.json from the documentation I didn't notice the missing quotes.  The `JSON.parse` command requires the quoted properties.
