### PR TITLE
remove heading.click so only clicking on the "paragraph" link refreshes ...

### DIFF
--- a/js/basic_skeleton.js
+++ b/js/basic_skeleton.js
@@ -1,4 +1,3 @@
-
 (function($) {
     var publicMethods = {
         createBasicSkeleton: function() {
@@ -167,9 +166,6 @@
             $heading.addClass('md-inpage-anchor');
             var text = $heading.clone().children('.anchor-highlight').remove().end().text();
             var href = $.md.util.getInpageAnchorHref(text);
-            $heading.click (function (){
-                window.location.hash = href;
-            });
             addPilcrow($heading, href);
         });
     }


### PR DESCRIPTION
...the page

I think it makes sense to only navigate away when clicking on the paragraph tag, instead of being able to click the header. What do you think?
