### PR TITLE
Responsive anchors

### DIFF
--- a/js/basic_skeleton.js
+++ b/js/basic_skeleton.js
@@ -193,7 +193,8 @@
 
         // adds a link to the navigation at the top of the page
         function addJumpLinkToTOC($heading) {
-            var $jumpLink = $('<a class="visible-xs visible-sm" href="#md-page-menu">[⬆]</a>');
+            var c = $.md.config.tocAnchor;
+            var $jumpLink = $('<a class="visible-xs visible-sm" href="#md-page-menu">' + c + '</a>');
             $jumpLink.click(function(ev) {
                 ev.preventDefault();
 

--- a/js/init.js
+++ b/js/init.js
@@ -21,7 +21,8 @@
         useSideMenu: true,
         lineBreaks: 'gfm',
         additionalFooterText: '',
-        anchorCharacter: '&para;'
+        anchorCharacter: '&para;',
+        tocAnchor: '[&#11014;]'
     };
 
 


### PR DESCRIPTION
Added anchors to H2 headers that jump to the navigation menu.  The anchors only show when the screen size is small and the navigation menu is moved to the top of the page.

The default anchor text is `[⬆]`, but this can be overridden in the `config.json` file by setting a value for `tocAnchor`.
