### PR TITLE
Fix jumplink sidemenu dependency

### DIFF
--- a/js/basic_skeleton.js
+++ b/js/basic_skeleton.js
@@ -195,7 +195,7 @@
         function addJumpLinkToTOC($heading) {
             if($.md.config.useSideMenu === false) return;
             if($heading.prop("tagName") !== 'H2') return;
-
+            
             var c = $.md.config.tocAnchor;
             if (c === '')
                 return;
@@ -208,7 +208,7 @@
             });
 
             if ($heading.parents('#md-menu').length === 0) {
-                $jumpLink.insertBefore($heading);
+                $jumpLink.insertAfter($heading);
             }
         }
 


### PR DESCRIPTION
- Fixes the bug where the `usesidemenu` config option should be considered before creating jump links
- Moves the links to **before** the headings
- Limits the application of the links to `H2` headings (for now)
