### PR TITLE
fix gimmicks gist 

### DIFF
--- a/js/gimmicks/gist.js
+++ b/js/gimmicks/gist.js
@@ -168,7 +168,8 @@
 
         } else if( content.indexOf( 'id="gist' ) !== -1 ) {
  	    expression = /https:\/\/gist.github.com\/.*\/(.*)#/.exec(content);
-            if( id !== undefined ) {
+            id = expression[1]; 
+	    if( id !== undefined ) {
 
                 // test if id is already loaded
                 if( $.inArray(id, ids_dom) !== -1 ) {


### PR DESCRIPTION
gimmicks gist doesn't work with long gist id like : 5cf6da58bff08ca1bfbf. 
I changed the regex to get the id from the gist href link at the bottom of the return content.
