### PR TITLE
removed forceHTTP from math fb and maps

### DIFF
--- a/js/gimmicks/facebooklike.js
+++ b/js/gimmicks/facebooklike.js
@@ -2,7 +2,7 @@
     var language = window.navigator.userLanguage || window.navigator.language;
     var code = language + "_" + language.toUpperCase();
     var fbRootDiv = $('<div id="fb-root" />');
-    var fbScriptHref = $.md.prepareLink ('connect.facebook.net/' + code + '/all.js#xfbml=1', { forceHTTP: true });
+    var fbScriptHref = $.md.prepareLink ('connect.facebook.net/' + code + '/all.js#xfbml=1');
     var fbscript ='(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "' + fbScriptHref + '"; fjs.parentNode.insertBefore(js, fjs);}(document, "script", "facebook-jssdk"));';
 
 

--- a/js/gimmicks/googlemaps.js
+++ b/js/gimmicks/googlemaps.js
@@ -8,7 +8,7 @@ function googlemapsReady() {
 
 (function($) {
     //'use strict';
-    var scripturl = 'http://maps.google.com/maps/api/js?sensor=false&callback=googlemapsReady';
+    var scripturl = 'https://maps.google.com/maps/api/js?sensor=false&callback=googlemapsReady';
 
     function googlemaps($links, opt, text) {
         var $maps_links = $links;

--- a/js/gimmicks/math.js
+++ b/js/gimmicks/math.js
@@ -10,7 +10,7 @@
                 processEscapes: true
             }
         };
-        var url = $.md.prepareLink('cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', { forceHTTP: true });
+        var url = $.md.prepareLink('cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML');
         var script = document.createElement('script');
         script.src = url;
         document.getElementsByTagName('head')[0].appendChild(script);


### PR DESCRIPTION
On modern browsers, running javascript from external sources without using SSL while viewing a page using SSL, the external source is blocked. This causes some of the MDwiki gimmicks (specifically the math, facebook like, and google maps) to not work.  Switching the external sources to allow SSL fixes this issue.

Since the facebooklike and math gimmicks both run javascript from external sources, I've removed the part of those gimmicks that forces the use of plain text connections. I did not force SSL but rather left it for prepareLink to decide which to use (by default it uses SSL when the MDwiki instance uses SSL).
