### PR TITLE
Add a header parser

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -23,6 +23,7 @@
     // PUBLIC API functions that are exposed
     var publicMethods = {
         bootstrapify: function () {
+            parseHeader();
             createPageSkeleton();
             buildMenu ();
             changeHeading();
@@ -57,6 +58,31 @@
     $.mdbootstrap.publicMethods = $.extend ({}, $.mdbootstrap.publicMethods, publicMethods);
 
     // PRIVATE FUNCTIONS:
+
+    function parseHeader() {
+        if ($.md.config.parseHeader) {
+            var parsedHeaders = {};
+            var header = $('#md-content > pre:first-child');
+            header.hide();
+            var headerLines = header.text().split("\n");
+            $.each(headerLines, function(n, elem) {
+                elem = elem.split(':', 2);
+                if (elem.length === 2) {
+                    parsedHeaders[elem[0].trim()] = elem[1].trim();
+                }
+            });
+            parsedHeaders.title = parsedHeaders.title || $('#md-title h1').text();
+            if (parsedHeaders.title) {
+                document.title = parsedHeaders.title;
+                $('meta[name=subject]').attr('content', parsedHeaders.title);
+            }
+            if (parsedHeaders.author) $('meta[name=author]').attr('content', parsedHeaders.author);
+            if (parsedHeaders.description) $('meta[name=description]').attr('content', parsedHeaders.description);
+            if (parsedHeaders.copyright) $('meta[name=copyright]').attr('content', parsedHeaders.copyright);
+            if (parsedHeaders.keywords) $('meta[name=keywords]').attr('content', parsedHeaders.keywords);
+            $('meta[name=generator]').attr('content', 'mdwiki');
+        }
+    }
 
     function buildTopNav() {
         // replace with the navbar skeleton

--- a/js/init.js
+++ b/js/init.js
@@ -25,7 +25,8 @@
             disable: false,
             returnAnchor: "[top]",
             useHeadings: "h2"
-        }
+        },
+        parseHeader: false
     };
 
     // the location of the main markdown file we display


### PR DESCRIPTION
You are now able to add this kind of headers on the top of your md files:

``````
```
title: This is the real title
author: John Doe <john.doe@datalove.com>
date: 2014-06-25
keywords: mdwiki, wiki, markdown
```
``````

It will be dynamically added to the _meta tags_ of your page.
Plus `document.title` will be set to the defined title, or defaults to
the first header (page first level 1 title).

You also have to set a _config.json_ property:

```
parseHeader: true
```
