### PR TITLE
Update link to highlight.js

### DIFF
--- a/index.md
+++ b/index.md
@@ -71,7 +71,7 @@ Cute kitten images provided by the great [placekitten.com] service.
   [colorbox]: http://www.jacklmoore.com/colorbox/
   [gists]: https://gist.github.com/
   [maps]: http://maps.google.com/
-  [highlightjs]: http://softwaremaniacs.org/soft/highlight/en/‎
+  [highlightjs]: https://highlightjs.org/
   [placekitten.com]: http://www.placekitten.com/
 
 License


### PR DESCRIPTION
The link to highlight.js currently links to the author's personal page, which he doesn't maintain anymore. This change links directly to the highlight.js home page.