### PR TITLE
Change gist regexp to support long ids with letter

### DIFF
--- a/js/gimmicks/gist.js
+++ b/js/gimmicks/gist.js
@@ -170,7 +170,7 @@
             }
 
         } else if( content.indexOf( 'id="gist' ) !== -1 ) {
-            expression = /gist([\d]{1,})/g.exec(content);
+            expression = /https:\/\/gist.github.com\/.*\/(.*)#/.exec(content);
             id = expression[1];
 
             if( id !== undefined ) {


### PR DESCRIPTION
This bug was already fixed in the master, but not in the 0.6.2 distribution.