### PR TITLE
Fix navbar template

### DIFF
--- a/templates/navigation/navbar.html
+++ b/templates/navigation/navbar.html
@@ -6,13 +6,13 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        {{#if pageTitle}}
+        {{#pageTitle}}
         <a class="navbar-brand" href="#"></a>
-        {{#/if}}
+        {{/pageTitle}}
     </div>
 
     <div class="collapse navbar-collapse navbar-ex1-collapse">
-        <ul class="nav navbar-nav" />;
+        <ul class="nav navbar-nav" />
         <ul class="nav navbar-nav navbar-right" />
     </div>
 </div>


### PR DESCRIPTION
- Fixed the template syntax to match that of Hogan's, which uses `#` and `/` in place of `if` and `/if`.
- Removed unnecessary semicolon.
