### PR TITLE
Add favicon gimmick.

### DIFF
--- a/js/gimmicks/favicon.js
+++ b/js/gimmicks/favicon.js
@@ -25,7 +25,7 @@
                 + ' alt="favicon"'
                 + '>';
 
-			var htmlLink = '<a href="' + e + '"'
+            var htmlLink = '<a href="' + e + '"'
                 + (options.target ? ' target="' + options.target + '"' : '')
                 + (options.cssClass ? ' class="' + options.cssClass + '"' : '')
                 + '>'

--- a/js/gimmicks/favicon.js
+++ b/js/gimmicks/favicon.js
@@ -17,21 +17,21 @@
 
             var $this = $(e);
 
-            var htmlImage = '<img src="https://www.google.com/s2/favicons?'
-                + (options.domain ? 'domain=' + options.domain : 'domain_url=' + e)
-                + (options.alt ? '&alt=' + options.alt : '')
-                + '" width="' + options.width + '"'
-                + ' height="' + options.height + '"'
-                + ' alt="favicon"'
-                + '>';
+            var htmlImage = '<img src="https://www.google.com/s2/favicons?' +
+                (options.domain ? 'domain=' + options.domain : 'domain_url=' + e) +
+                (options.alt ? '&alt=' + options.alt : '') +
+                '" width="' + options.width + '"' +
+                ' height="' + options.height + '"' +
+                ' alt="favicon"' +
+                '>';
 
-            var htmlLink = '<a href="' + e + '"'
-                + (options.target ? ' target="' + options.target + '"' : '')
-                + (options.cssClass ? ' class="' + options.cssClass + '"' : '')
-                + '>'
-                + htmlImage
-                + (options.caption ? ' ' + options.caption : '')
-                + '</a>';
+            var htmlLink = '<a href="' + e + '"' +
+                (options.target ? ' target="' + options.target + '"' : '') +
+                (options.cssClass ? ' class="' + options.cssClass + '"' : '') +
+                '>' +
+                htmlImage +
+                (options.caption ? ' ' + options.caption : '') +
+                '</a>';
 
             $this.replaceWith(htmlLink);
         });

--- a/js/gimmicks/favicon.js
+++ b/js/gimmicks/favicon.js
@@ -1,0 +1,53 @@
+(function($) {
+    'use strict';
+    function favicon($link, opt, text) {
+
+        var default_options = {
+            width:    16,   /* image width          */
+            height:   16,   /* image height         */
+            alt:      '',   /* alternative favicon  */
+            domain:   '',   /* favicon domain       */
+            caption:  text, /* link caption         */
+            target:   '',   /* link target          */
+            cssClass: ''    /* link css class       */
+        };
+        var options = $.extend ({}, default_options, opt);
+
+        return $link.each( function(i,e){
+
+            var $this = $(e);
+
+            var htmlImage = '<img src="https://www.google.com/s2/favicons?'
+                + (options.domain ? 'domain=' + options.domain : 'domain_url=' + e)
+                + (options.alt ? '&alt=' + options.alt : '')
+                + '" width="' + options.width + '"'
+                + ' height="' + options.height + '"'
+                + ' alt="favicon"'
+                + '>';
+
+			var htmlLink = '<a href="' + e + '"'
+                + (options.target ? ' target="' + options.target + '"' : '')
+                + (options.cssClass ? ' class="' + options.cssClass + '"' : '')
+                + '>'
+                + htmlImage
+                + (options.caption ? ' ' + options.caption : '')
+                + '</a>';
+
+            $this.replaceWith(htmlLink);
+        });
+    }
+    var faviconGimmick = {
+        name: 'favicon',
+        version: $.md.version,
+        once: function() {
+            $.md.linkGimmick(this, 'favicon', favicon);
+            $.md.registerScript(this, '', {
+                license: 'LGPL',
+                loadstage: 'postgimmick',
+                finishstage: 'all_ready'
+            });
+        }
+    };
+    $.md.registerGimmick(faviconGimmick);
+
+}(jQuery));


### PR DESCRIPTION
This gimmick creates **a link containing a favicon** (through *Google S2 API*).

For example:

    [gimmick:favicon](https://github.com/)

Becomes:

    <a href="https://github.com/">
      <img src="https://www.google.com/s2/favicons?domain_url=https://github.com/" width="16" height="16" alt="favicon">
      https://github.com/
    </a>

Available options are:

- `width`: image width
- `height`: image height
- `alt`: alternative favicon (when it is not found). Examples: `feed`, `p`
- `domain`: grab favicon from domain (instead of link)
- `caption`: link caption
- `target`: link target
- `cssClass`: link CSS class