### PR TITLE
Added ability to specify url scheme and host + path to the gist gimmick

### DIFF
--- a/js/gimmicks/gist.js
+++ b/js/gimmicks/gist.js
@@ -11,12 +11,17 @@
     function gist($links, opt, href) {
         $().lazygist('init');
         return $links.each(function(i,link) {
+            var default_options = {
+                scheme: 'https',
+                path: 'gist.github.com/'
+            };
+            var options = $.extend (default_options, opt);
             var $link = $(link);
             var gistDiv = $('<div class="gist_here" data-id="' + href + '" />');
             $link.replaceWith(gistDiv);
             gistDiv.lazygist({
                 // we dont want a specific file so modify the url template
-                url_template: 'https://gist.github.com/{id}.js?'
+                url_template: '{scheme}://{path}{id}.js'.replace(/\{scheme\}/g, options.scheme).replace(/\{path\}/g, options.path)
             });
         });
     }
@@ -170,9 +175,17 @@
             }
 
         } else if( content.indexOf( 'id="gist' ) !== -1 ) {
-            expression = /https:\/\/gist.github.com\/.*\/(.*)#/.exec(content);
-            id = expression[1];
-
+            // This is the newer gist URL style, ignoring the hostname for GitHub EE instances
+            expression = /https?:\/\/gist.*?\/.*\/(.*)#/.exec(content);
+            if(expression !== null) {
+                id = expression[1];
+            } else {
+                // This will catch older versions of GitHub EE
+                expression = /gist\/.+?\/([a-f0-9]+)\/raw/g.exec(content);
+                if(expression !== null) {
+                    id = expression[1];
+                }
+            }
             if( id !== undefined ) {
 
                 // test if id is already loaded


### PR DESCRIPTION
So that the gimmick now supports displaying gists from private GitHub Enterprise Edition sites. So for a github.com gist nothing changes: `[gimmick:gist](12f42033f1b9b961cc8b)`. But to display a gist from a private GitHub Enterprise Edition site you have to give it the scheme and hostname and path: `[gimmick:gist(scheme: 'http', path: 'github.abcd.company.com/gist/')](6453757a4fdc2f9e6c14)`. On older installs the path is `hosname.tld/gist/` while on newer versions it's `gist.hostname.tld/`. This change will handle either type.

If you don't have a GitHub EE site to test it on the best I can do is show you a screenshot to prove that it works:

![GitHub EE Gist](http://i.imgur.com/7HtVbvi.png)
