### PR TITLE
Fix for gist gimmick issue with alpha-numeric IDs

### DIFF
--- a/js/gimmicks/gist.js
+++ b/js/gimmicks/gist.js
@@ -167,8 +167,8 @@
             }
 
         } else if( content.indexOf( 'id="gist' ) !== -1 ) {
-            expression = /https:\/\/gist.github.com\/.*\/(.*)#/.exec(content);
-            id = expression[1];
+            expression = /https:\/\/gist.github.com\/(\w{1,})\/([0-9a-z]{1,})\//g.exec(content);
+            id = expression[2];
 
             if( id !== undefined ) {
 


### PR DESCRIPTION
Fix for issue https://github.com/Dynalon/mdwiki/issues/150

I've test it with new alpha-numeric IDs and old ones and it works from my side.
