### PR TITLE
Fix paragraph character display problem in Firefox

### DIFF
--- a/js/ts/basic_skeleton.ts
+++ b/js/ts/basic_skeleton.ts
@@ -191,7 +191,7 @@ module MDwiki.Legacy {
                     mouse_entered = true;
                     MDwiki.Utils.Util.wait(300).then(function () {
                         if (!mouse_entered) return;
-                        $pilcrow.fadeIn(200);
+                        $pilcrow.fadeIn(200).css('display', 'inline');
                     });
                 });
                 $heading.mouseleave(function () {


### PR DESCRIPTION
In Chrome, the paragraph character element style is "display: inline", while in Firefox, the style is "display: block", and the paragraph character shows below in another line.