### PR TITLE
validation of the href

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ unittests/lib/
 .DS_Store
 .AppleDouble
 .idea/
+.tscache

--- a/js/ts/main.ts
+++ b/js/ts/main.ts
@@ -38,6 +38,22 @@ declare var MDwikiEnableDebug: any;
                 } else {
                     href = window.location.hash.substring(1);
                 }
+
+                // Validation of the href 
+                var parser = document.createElement('a');
+                console.log('-------------------------');
+                console.log('Validation and Sanitization of the href');
+                parser.href = href;
+                console.log("href: " + href);
+                console.log("current domain: " + window.location.hostname);
+                console.log("requested domain: " + parser.hostname);
+                if (window.location.hostname != parser.hostname) {
+                    console.error("invalid href");
+                    // fall to default
+                    href = 'index.md';
+                }
+                console.log('-------------------------');
+
                 href = decodeURIComponent(href);
 
                 // extract possible in-page anchor

--- a/js/ts/main.ts
+++ b/js/ts/main.ts
@@ -41,18 +41,11 @@ declare var MDwikiEnableDebug: any;
 
                 // Validation of the href 
                 var parser = document.createElement('a');
-                console.log('-------------------------');
-                console.log('Validation and Sanitization of the href');
                 parser.href = href;
-                console.log("href: " + href);
-                console.log("current domain: " + window.location.hostname);
-                console.log("requested domain: " + parser.hostname);
                 if (window.location.hostname != parser.hostname) {
-                    console.error("invalid href");
                     // fall to default
                     href = 'index.md';
                 }
-                console.log('-------------------------');
 
                 href = decodeURIComponent(href);
 


### PR DESCRIPTION
Validation of the href. This update fixes a security vulnerability (XSS). The extracted hash from the url should match the current domain.

<img width="896" alt="screen shot 2017-12-28 at 6 38 37 pm" src="https://user-images.githubusercontent.com/1000203/34419914-5d7c9454-ebfe-11e7-855e-63ac4d3a904c.png">
