### PR TITLE
Use https for external resources

### DIFF
--- a/js/gimmicks/disqus.js
+++ b/js/gimmicks/disqus.js
@@ -6,7 +6,7 @@
             identifier: ''
         };
         var options = $.extend (default_options, opt);
-        var disqus_div = $('<div id="disqus_thread" class="md-external md-external-noheight md-external-nowidth" >' + '<a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a></div>');
+        var disqus_div = $('<div id="disqus_thread" class="md-external md-external-noheight md-external-nowidth" >' + '<a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a></div>');
         disqus_div.css ('margin-top', '2em');
         return $links.each(function(i,link) {
             if (alreadyDone === true) {
@@ -47,7 +47,7 @@
                         var dsq = document.createElement('script');
                         dsq.type = 'text/javascript';
                         dsq.async = true;
-                        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                     })();
                 }

--- a/js/gimmicks/facebooklike.js
+++ b/js/gimmicks/facebooklike.js
@@ -2,7 +2,7 @@
     var language = window.navigator.userLanguage || window.navigator.language;
     var code = language + "_" + language.toUpperCase();
     var fbRootDiv = $('<div id="fb-root" />');
-    var fbScriptHref = $.md.prepareLink ('connect.facebook.net/' + code + '/all.js#xfbml=1', { forceHTTP: true });
+    var fbScriptHref = $.md.prepareLink ('connect.facebook.net/' + code + '/all.js#xfbml=1', { forceSSL: true });
     var fbscript ='(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "' + fbScriptHref + '"; fjs.parentNode.insertBefore(js, fjs);}(document, "script", "facebook-jssdk"));';
 
 

--- a/js/gimmicks/googlemaps.js
+++ b/js/gimmicks/googlemaps.js
@@ -8,7 +8,7 @@ function googlemapsReady() {
 
 (function($) {
     //'use strict';
-    var scripturl = 'http://maps.google.com/maps/api/js?sensor=false&callback=googlemapsReady';
+    var scripturl = 'https://maps.google.com/maps/api/js?sensor=false&callback=googlemapsReady';
 
     function googlemaps(trigger, text, options, domElement) {
         var $maps_links = $(domElement);

--- a/js/gimmicks/leaflet.js
+++ b/js/gimmicks/leaflet.js
@@ -1,7 +1,7 @@
 (function($) {
     //'use strict';
-    var jsUrl = 'http://cdn.leafletjs.com/leaflet-0.5.1/leaflet.js';
-    var cssUrl = 'http://cdn.leafletjs.com/leaflet-0.5.1/leaflet.css';
+    var jsUrl = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.5.1/leaflet.js';
+    var cssUrl = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.5.1/leaflet.css';
 
     function leaflet_map($link, opt, linkText) {
         var $maps_links = $link;

--- a/js/gimmicks/math.js
+++ b/js/gimmicks/math.js
@@ -10,7 +10,7 @@
                 processEscapes: true
             }
         };
-        var url = $.md.prepareLink('cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', { forceHTTP: true });
+        var url = $.md.prepareLink('cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML', { forceSSL: true });
         var script = document.createElement('script');
         script.src = url;
         document.getElementsByTagName('head')[0].appendChild(script);

--- a/js/gimmicks/youtube_embed.js
+++ b/js/gimmicks/youtube_embed.js
@@ -15,7 +15,7 @@
                     // insert the iframe
                     var short_handle = m[1];
                     var frame = $('<iframe class="md-external" frameborder="0" allowfullscreen></iframe>');
-                    frame.attr('src', 'http://youtube.com/embed/' + short_handle);
+                    frame.attr('src', 'https://youtube.com/embed/' + short_handle);
                     // remove the a tag
                     $this.replaceWith(frame);
 

--- a/js/gimmicks/yuml.js
+++ b/js/gimmicks/yuml.js
@@ -46,7 +46,7 @@
         return $link.each(function(i,e) {
 
             var $this = $(e);
-            var url = 'http://yuml.me/diagram/';
+            var url = 'https://yuml.me/diagram/';
             var data = $this.attr('href');
             var title = $this.attr('title');
 

--- a/js/ts/theme.ts
+++ b/js/ts/theme.ts
@@ -161,12 +161,8 @@ module MDwiki.Core {
             $chooser.eq(1).append($li);
 
             $chooser.eq(1).append('<li class="divider" />');
-            $chooser.eq(1).append('<li><a href="http://www.bootswatch.com">Powered by Bootswatch</a></li>');
+            $chooser.eq(1).append('<li><a href="https://www.bootswatch.com">Powered by Bootswatch</a></li>');
             $this.replaceWith($chooser);
         });
     };
 }
-
-
-
-

--- a/unittests/rendered-markdown/paragraph.html
+++ b/unittests/rendered-markdown/paragraph.html
@@ -6,7 +6,7 @@
 
  <section id="single-paragraph-with-left-float-image">
     <p>
-        <img src="http://placekitten.com/g/200/200"></img>
+        <img src="https://placekitten.com/g/200/200"></img>
         This is a sentence.
     </p>
 </section>
@@ -14,13 +14,13 @@
 <section id="single-paragraph-with-right-float-image">
     <p>
         This is a sentence.
-        <img src="http://placekitten.com/g/200/200"></img>
+        <img src="https://placekitten.com/g/200/200"></img>
     </p>
 </section>
 
 <section id="single-paragraph-with-image-and-link">
     <p>
         This is a sentence that contains <a href="#">a link</a>.
-        <img src="http://placekitten.com/g/200/200"></img>
+        <img src="https://placekitten.com/g/200/200"></img>
     </p>
 </section>


### PR DESCRIPTION
I checked all the external resources used by gimmicks, etc. and switched them to use the https:// protocol whenever that was available (it was available for all of them).

Merging this PR will close the following issues:
- fixes #342 
- fixes #330 
- fixes #252 
- fixes #196 

It will also solve #146 if the gh-pages branch is updated with this change.

### Why not use protocol relative links?

See https://www.paulirish.com/2010/the-protocol-relative-url/ and https://jeremywagner.me/blog/stop-using-the-protocol-relative-url/

> Now that SSL is [encouraged for everyone](https://www.eff.org/encrypt-the-web-report) and [doesn’t have performance concerns](https://istlsfastyet.com/), **this technique is now an anti-pattern**. If the asset you need is available on SSL, then **always** use the `https://` asset.
> 
> Allowing the snippet to request over HTTP opens the door for attacks like the [recent Github Man-on-the-side attack](http://www.netresec.com/?page=Blog&month=2015-03&post=China%27s-Man-on-the-Side-Attack-on-GitHub). It’s always safe to request HTTPS assets even if your site is on HTTP, however the reverse is [not true](https://developer.mozilla.org/en-US/docs/Security/MixedContent/How_to_fix_website_with_mixed_content).