### PR TITLE
fix(docs) Replaced placekitten.com with placecats.com in image float examples

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ MDwiki would not exist if it weren't for those great pieces of software:
 
 MDwiki is created by Timo Dörr. Follow me to get updates on MDwiki! [Follow @timodoerr](http://www.twitter.com/timodoerr).
 
-Cute kitten images provided by the great [placekitten.com] service.
+Cute cat images provided by the great [placecats.com] service.
 
 [download]: download.md
 [quickstart]: quickstart.md
@@ -63,7 +63,7 @@ Cute kitten images provided by the great [placekitten.com] service.
 [gists]: https://gist.github.com/
 [maps]: http://maps.google.com/
 [highlightjs]: https://highlightjs.org/
-[placekitten.com]: http://www.placekitten.com/
+[placecats.com]: http://www.placecats.com/
 
 ## License
 

--- a/layout.md
+++ b/layout.md
@@ -29,13 +29,13 @@ Standard Markdown provides no way to influence the layout of your resulting webs
 
 If the image(s) are placed at the top of the paragraph, *without* any blank line between the image(s) and the paragraph, the image(s) will float left.
 
-    ![](http://placekitten.com/g/800/800)
+    ![](http://placecats.com/800/800)
     The above image floats left to this text.
     Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
 
 Example:
 
-![](http://placekitten.com/g/800/800)
+![](http://placecats.com/800/800)
 *To the left you will find an image that this text flows around to*. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. [Typi non habent claritatem](#) insitam; est usus legentis in iis qui facit eorum claritatem. Investigationes demonstraverunt lectores legere me lius quod ii legunt saepius. Claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. Mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim
 Lorem ipsum dolor sit amet, it *esse* molestie consequat dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet **doming** id quod mazim placerat facer possim assum. Typi non habent claritatem *kursiv* consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobor
 
@@ -45,13 +45,13 @@ If the image(s) are placed at the bottom of the paragraph, *without* any blank l
 
     The images below float right to this text.
     Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
-    ![](http://placekitten.com/g/600/600)
-    ![](http://placekitten.com/g/600/600)
+    ![](http://placecats.com/600/600)
+    ![](http://placecats.com/600/600)
 
 *To the right you will find two images, that are floated*. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
-![](http://placekitten.com/g/600/600)
-![](http://placekitten.com/g/600/600)
+![](http://placecats.com/600/600)
+![](http://placecats.com/600/600)
 
 ### No floating
 
@@ -59,13 +59,13 @@ A blank line before or after the image(s) disables any floating.
 
 Source:
 
-    ![](http://placekitten.com/g/600/350)
-    ![](http://placekitten.com/g/600/350)
+    ![](http://placecats.com/600/350)
+    ![](http://placecats.com/600/350)
 
     This text is preceded by two images, that span across the whole Page width.
 
-![](http://placekitten.com/g/600/350)
-![](http://placekitten.com/g/600/350)
+![](http://placecats.com/600/350)
+![](http://placecats.com/600/350)
 
 *This text is preceeded by two images, that span across the whole Page width*.
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#) luptatum zzril delenit augue duis dolore te feugait nulla facilisi. nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. typi non habent claritatem insitam; est usus legentis in iis qui facit eorum claritatem. investigationes demonstraverunt lectores legere me lius [quod ii legunt](#) saepius. claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim.
@@ -73,20 +73,20 @@ ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismo
 
 ### Mixing floats it all together
 
-![](http://placekitten.com/g/600/400)
-![](http://placekitten.com/g/600/400)
+![](http://placecats.com/600/400)
+![](http://placecats.com/600/400)
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#).
 magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros.
 
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#)
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#)
-![](http://placekitten.com/g/560/450)
-![](http://placekitten.com/g/560/450)
+![](http://placecats.com/560/450)
+![](http://placecats.com/560/450)
 
-![](http://placekitten.com/g/700/580)
+![](http://placecats.com/700/580)
 luptatum zzril delenit augue duis dolore te feugait nulla facilisi. nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. typi non habent claritatem insitam; est usus legentis in iis qui facit eorum claritatem. investigationes demonstraverunt lectores legere me lius [quod ii legunt](#) saepius. claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim.
 luptatum zzril delenit augue duis dolore te feugait nulla facilisi. nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. typi non habent claritatem insitam; est usus legentis in iis qui facit eorum claritatem. investigationes demonstraverunt lectores legere me lius [quod ii legunt](#) saepius. claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim.
 
-![](http://placekitten.com/g/540/450)
-![](http://placekitten.com/g/435/450)
-![](http://placekitten.com/g/420/340)
+![](http://placecats.com/540/450)
+![](http://placecats.com/435/450)
+![](http://placecats.com/420/340)

--- a/quickstart.md
+++ b/quickstart.md
@@ -25,7 +25,7 @@ SubHeading
   This is a hyperlink to [Google](http://google.com).
 
   Images are like hyperlinks, but with an exclamation mark in front of them:
-  ![](http://placekitten.com/g/250/250)
+  ![](http://placecats.com/250/250)
 
 ```
 
@@ -123,25 +123,25 @@ Images are regularly placed as in standard markdown using the `![alt](href "titl
 
 Example:
 
-    ![](http://placekitten.com/g/1200/300 "A kitten")
+    ![](http://placecats.com/1200/300 "A cat")
 
-    ![](http://placekitten.com/g/550/450 "First of two kittens")
-    ![](http://placekitten.com/g/550/450 "Second of two kittens")
+    ![](http://placecats.com/550/450 "First of two cats")
+    ![](http://placecats.com/550/450 "Second of two cats")
 
-    ![](http://placekitten.com/g/400/350)
-    ![](http://placekitten.com/g/400/350)
-    ![](http://placekitten.com/g/400/350)
+    ![](http://placecats.com/400/350)
+    ![](http://placecats.com/400/350)
+    ![](http://placecats.com/400/350)
 
 Will be rendered as:
 
-![](http://placekitten.com/g/1200/300 "A kitten")
+![](http://placecats.com/1200/300 "A cat")
 
-![](http://placekitten.com/g/550/450 "First of two kittens")
-![](http://placekitten.com/g/550/450 "Second of two kittens")
+![](http://placecats.com/550/450 "First of two cats")
+![](http://placecats.com/550/450 "Second of two cats")
 
-![](http://placekitten.com/g/400/350)
-![](http://placekitten.com/g/400/350)
-![](http://placekitten.com/g/400/350)
+![](http://placecats.com/400/350)
+![](http://placecats.com/400/350)
+![](http://placecats.com/400/350)
 
 ### Images as Links
 
@@ -150,9 +150,9 @@ To use an image as a link, use the following syntax:
     [![ImageCaption](path/to/image.png)](http://www.linktarget.com)
 
     Example:
-    [![A kitten](http://placekitten.com/g/400/400)](http://www.placekitten.com)
+    [![A cat](http://placecats.com/400/400)](http://www.placecats.com)
 
-[![A kitten](http://placekitten.com/g/400/400)](http://www.placekitten.com)
+[![A cat](http://placecats.com/400/400)](http://www.placecats.com)
 
 - - - -
 

--- a/unstable/index.md
+++ b/unstable/index.md
@@ -54,7 +54,7 @@ MDwiki would not exist if it weren't for those great pieces of software:
 
 MDwiki is created by Timo Dörr. Follow me to get updates on MDwiki! [Follow @timodoerr](http://www.twitter.com/timodoerr).
 
-Cute kitten images provided by the great [placekitten.com] service.
+Cute cat images provided by the great [placecats.com] service.
 
   [download]: download.md
   [quickstart]: quickstart.md
@@ -69,7 +69,7 @@ Cute kitten images provided by the great [placekitten.com] service.
   [gists]: https://gist.github.com/
   [maps]: http://maps.google.com/
   [highlightjs]: http://softwaremaniacs.org/soft/highlight/en/‎
-  [placekitten.com]: http://www.placekitten.com/
+  [placecats.com]: http://www.placecats.com/
 
 License
 -------

--- a/unstable/layout.md
+++ b/unstable/layout.md
@@ -29,13 +29,13 @@ Standard Markdown provides no way to influence the layout of your resulting webs
 
 If the image(s) are placed at the top of the paragraph, *without* any blank line between the image(s) and the paragraph, the image(s) will float left.
 
-    ![](http://placekitten.com/g/800/800)
+    ![](http://placecats.com/800/800)
     The above image floats left to this text.
     Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
 
 Example:
 
-![](http://placekitten.com/g/800/800)
+![](http://placecats.com/800/800)
 *To the left you will find an image that this text flows around to*. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. [Typi non habent claritatem](#) insitam; est usus legentis in iis qui facit eorum claritatem. Investigationes demonstraverunt lectores legere me lius quod ii legunt saepius. Claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. Mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim
 Lorem ipsum dolor sit amet, it *esse* molestie consequat dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet **doming** id quod mazim placerat facer possim assum. Typi non habent claritatem *kursiv* consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobor
 
@@ -45,13 +45,13 @@ If the image(s) are placed at the bottom of the paragraph, *without* any blank l
 
     The images below float right to this text.
     Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.
-    ![](http://placekitten.com/g/600/600)
-    ![](http://placekitten.com/g/600/600)
+    ![](http://placecats.com/600/600)
+    ![](http://placecats.com/600/600)
 
 *To the right you will find two images, that are floated*. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.
-![](http://placekitten.com/g/600/600)
-![](http://placekitten.com/g/600/600)
+![](http://placecats.com/600/600)
+![](http://placecats.com/600/600)
 
 ### No floating
 
@@ -59,13 +59,13 @@ A blank line before or after the image(s) disables any floating.
 
 Source:
 
-    ![](http://placekitten.com/g/600/350)
-    ![](http://placekitten.com/g/600/350)
+    ![](http://placecats.com/600/350)
+    ![](http://placecats.com/600/350)
 
     This text is preceded by two images, that span across the whole Page width.
 
-![](http://placekitten.com/g/600/350)
-![](http://placekitten.com/g/600/350)
+![](http://placecats.com/600/350)
+![](http://placecats.com/600/350)
 
 *This text is preceeded by two images, that span across the whole Page width*.
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#) luptatum zzril delenit augue duis dolore te feugait nulla facilisi. nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. typi non habent claritatem insitam; est usus legentis in iis qui facit eorum claritatem. investigationes demonstraverunt lectores legere me lius [quod ii legunt](#) saepius. claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim.
@@ -73,20 +73,20 @@ ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismo
 
 ### Mixing floats it all together
 
-![](http://placekitten.com/g/600/400)
-![](http://placekitten.com/g/600/400)
+![](http://placecats.com/600/400)
+![](http://placecats.com/600/400)
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#).
 magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros.
 
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#)
 ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio [dignissim qui blandit praesent](#)
-![](http://placekitten.com/g/560/450)
-![](http://placekitten.com/g/560/450)
+![](http://placecats.com/560/450)
+![](http://placecats.com/560/450)
 
-![](http://placekitten.com/g/700/580)
+![](http://placecats.com/700/580)
 luptatum zzril delenit augue duis dolore te feugait nulla facilisi. nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. typi non habent claritatem insitam; est usus legentis in iis qui facit eorum claritatem. investigationes demonstraverunt lectores legere me lius [quod ii legunt](#) saepius. claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim.
 luptatum zzril delenit augue duis dolore te feugait nulla facilisi. nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. typi non habent claritatem insitam; est usus legentis in iis qui facit eorum claritatem. investigationes demonstraverunt lectores legere me lius [quod ii legunt](#) saepius. claritas est etiam processus dynamicus, qui sequitur mutationem consuetudium lectorum. mirum est notare quam littera gothica, quam nunc putamus parum claram, anteposuerit litterarum formas humanitatis per seacula quarta decim.
 
-![](http://placekitten.com/g/540/450)
-![](http://placekitten.com/g/435/450)
-![](http://placekitten.com/g/420/340)
+![](http://placecats.com/540/450)
+![](http://placecats.com/435/450)
+![](http://placecats.com/420/340)

--- a/unstable/quickstart.md
+++ b/unstable/quickstart.md
@@ -25,7 +25,7 @@ SubHeading
   This is a hyperlink to [Google](http://google.com).
 
   Images are like hyperlinks, but with an exclamation mark in front of them:
-  ![](http://placekitten.com/g/250/250)
+  ![](http://placecats.com/250/250)
 
 ```
 
@@ -123,25 +123,25 @@ Images are regularly placed as in standard markdown using the `![alt](href "titl
 
 Example:
 
-    ![](http://placekitten.com/g/1200/300 "A kitten")
+    ![](http://placecats.com/1200/300 "A cat")
 
-    ![](http://placekitten.com/g/550/450 "First of two kittens")
-    ![](http://placekitten.com/g/550/450 "Second of two kittens")
+    ![](http://placecats.com/550/450 "First of two cats")
+    ![](http://placecats.com/550/450 "Second of two cats")
 
-    ![](http://placekitten.com/g/400/350)
-    ![](http://placekitten.com/g/400/350)
-    ![](http://placekitten.com/g/400/350)
+    ![](http://placecats.com/400/350)
+    ![](http://placecats.com/400/350)
+    ![](http://placecats.com/400/350)
 
 Will be rendered as:
 
-![](http://placekitten.com/g/1200/300 "A kitten")
+![](http://placecats.com/1200/300 "A cat")
 
-![](http://placekitten.com/g/550/450 "First of two kittens")
-![](http://placekitten.com/g/550/450 "Second of two kittens")
+![](http://placecats.com/550/450 "First of two cats")
+![](http://placecats.com/550/450 "Second of two cats")
 
-![](http://placekitten.com/g/400/350)
-![](http://placekitten.com/g/400/350)
-![](http://placekitten.com/g/400/350)
+![](http://placecats.com/400/350)
+![](http://placecats.com/400/350)
+![](http://placecats.com/400/350)
 
 ### Images as Links
 
@@ -150,9 +150,9 @@ To use an image as a link, use the following syntax:
     [![ImageCaption](path/to/image.png)](http://www.linktarget.com)
 
     Example:
-    [![A kitten](http://placekitten.com/g/400/400)](http://www.placekitten.com)
+    [![A cat](http://placecats.com/400/400)](http://www.placecats.com)
 
-[![A kitten](http://placekitten.com/g/400/400)](http://www.placekitten.com)
+[![A cat](http://placecats.com/400/400)](http://www.placecats.com)
 
 - - - -
 


### PR DESCRIPTION
Hey,
I noticed that the placekitten.com service used in your documentation for image float examples seems to be dead — there is a comparable service in placecats.com, so I've updated the documentation to use that.

I've also updated the documentation in `unstable/` but I'm unclear whether this is still relevant to the project as it stands or abandoned.